### PR TITLE
Customize Spectrum's buttons and field labels

### DIFF
--- a/style.css
+++ b/style.css
@@ -74,3 +74,19 @@ progress::-webkit-progress-value {
   width: 600px !important;
   max-width: 100% !important;
 }
+
+/* Buttons */
+
+.spectrum-Button {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+/* Field Labels */
+
+.spectrum-FieldLabel {
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 4px;
+  color: var(--grey-9);
+}


### PR DESCRIPTION
## What Happened  👀

- Customized Spectrum's Button that has asymmetric vertical padding (top +1 and bottom -1). Think it's to justify the font, but we are forcing IBM Plex Sans Thai where it already vertically centers without it.
- Styled Field Labels to follow our design so that we can use Label value on Form Fields

## Proof of Work 💪

![screenshot of your PoW](https://i.imgur.com/Z58M4Kc.png)