### PR TITLE
Override button variants

### DIFF
--- a/style.css
+++ b/style.css
@@ -82,6 +82,31 @@ progress::-webkit-progress-value {
   padding-bottom: 0;
 }
 
+.spectrum-Button--primary {
+  color: white;
+  background-color: var(--green-green);
+  border-color: var(--green-green);
+}
+
+.spectrum-Button--primary:hover {
+  background-color: #48a058;
+  border-color: #48a058;
+}
+
+.spectrum-Button--secondary {
+  border-color: var(--grey-4);
+}
+
+.spectrum-Button--secondary:hover {
+  color: var(--grey-7);
+  background-color: var(--grey-2);
+  border-color: var(--grey-2);
+}
+
+.spectrum-Button--warning:hover {
+  border-color: var(--red-light);
+}
+
 /* Field Labels */
 
 .spectrum-FieldLabel {


### PR DESCRIPTION
## What Happened  👀

Override Spectrum Button's variants to match the design and avoid having to customize in too many places.

## Proof of Work 💪

![Screenshot 2566-02-14 at 04 42 19](https://user-images.githubusercontent.com/13864215/218581145-fbd8eeda-e682-4ae0-8bd1-d13b084f2eea.png)