### PR TITLE
Customize Warning button variant's border color to Grey 4

### DIFF
--- a/style.css
+++ b/style.css
@@ -103,6 +103,10 @@ progress::-webkit-progress-value {
   border-color: var(--grey-2);
 }
 
+.spectrum-Button--warning {
+  border-color: var(--grey-4);
+}
+
 .spectrum-Button--warning:hover {
   border-color: var(--red-light);
 }


### PR DESCRIPTION
## What Happened  👀

Just a quick one. Customized the Warning Button variant's to Grey 4 instead of Red

## Proof of Work 💪

![Screenshot 2566-02-14 at 15 13 41](https://user-images.githubusercontent.com/13864215/218677405-e49ae91b-a393-4766-ac74-96c1bdfc2141.png)
